### PR TITLE
entrypoint: allow passing custom options to mergerfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,21 @@ services:
     restart: always
 ```
 
-## Customizing
-* If you would like to customize the mergerfs command with additional options, you can overwrite entrypoint.sh by mounting your own using an additional volume mount.
-* If you would like to combine this with samba to share it over the network, you could also use a samba docker container.
+
+## Environnment variables
+
+The following environnement variables allow to change mergerFS options:
+
+You can provide a list of custom options:
+* `MERGERFS_OPTIONS="cache.files=partial,dropcacheonclose=true,category.create=mfs"`
+
+Or pass a config file through a volume:
+* MERGERFS_CONFIG_PATH=/etc/mergerfs/config
+Note that specyfing a config will ignore `MERGERFS_OPTIONS`.
+
+These will overwrite the default options provided in the image entrypoint so make sure you know what you are doing.
+See [trapexit/mergerfs options reference](https://github.com/trapexit/mergerfs?tab=readme-ov-file#mount-options) for more details on available options.
+
 
 ## Acknowledgements
 The following resources have been extremely helpful:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,19 @@
 #!/bin/sh
+set -exo pipefail
 
 function cleanup {
     umount /merged
 }
 
-mergerfs -o allow_other,use_ino,cache.files=partial,dropcacheonclose=true,moveonenospc=true,category.create=mfs /disks/*: /merged
+# Assign default options if nothing is specified
+OPTIONS=${MERGERFS_OPTIONS:-"allow_other,use_ino,cache.files=partial,dropcacheonclose=true,moveonenospc=true,category.create=mfs"}
+
+# if a path to a config file is set, it takes precedence
+if [ -n "${MERGERFS_CONFIG_PATH}" ]; then
+    OPTIONS="config=${MERGERFS_CONFIG_PATH}"
+fi
+
+mergerfs -o "${OPTIONS}" /disks/*: /merged
 
 
 trap cleanup EXIT INT


### PR DESCRIPTION
Add a couple of environnement variables to allow passing custom options to mergerfs.

Passing a config path will discard any previously set options. Of course we keep the default options set as-is to not break any compatibility.

The config file should be mounted to the container through a volume